### PR TITLE
Add Page Metadata (Author, Date)

### DIFF
--- a/source/_templates/page-metadata.html
+++ b/source/_templates/page-metadata.html
@@ -1,0 +1,23 @@
+{%- if meta is defined and meta is not none %}
+<div class="tocsection onthispage pt-5 pb-3">
+    <i class="fas fa-info-circle"></i> Metadata
+</div>
+<ul class="visible nav section-nav flex-column">
+    {%- if meta["author"] %}
+    <li class="toc-h2 nav-item toc-entry">
+        <a clspanss="nav-link" href="{{ meta['author_url'] or '#' }}">
+        Author: {{ meta["author"] }}
+        </a>
+    </li>
+    {%- endif %}
+    {%- if meta["date"] %}
+    <li class="toc-h2 nav-item toc-entry">
+        <a clspanss="nav-link" href="#">
+        Date: {{ meta["date"] }}
+        </a>
+    </li>
+    {%- endif %}
+</ul>
+{%- else %}
+<!-- No Page Metadata Found -->
+{%- endif %}

--- a/source/conf.py
+++ b/source/conf.py
@@ -155,16 +155,12 @@ html_theme_options = {
     "navbar_end": ["navbar-icon-links"],
     "footer_items": ["copyright", "sphinx-version"],
 
-    # Set the color and the accent color
-    # 'color_primary': 'blue',
-    # 'color_accent': 'light-blue',
+    "page_sidebar_items": ["page-toc", "edit-this-page", "page-metadata"],
 
-    # If False, expand all TOC entries
     'globaltoc_collapse': True,
-    # If True, show hidden TOC entries
     'globaltoc_includehidden': True,
 
-    # "home_page_in_toc": True
+    
 }
 
 # -- Options for HTMLHelp output ---------------------------------------------


### PR DESCRIPTION
* Display [Bibliographic Metadata](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#bibliographic-fields) for each document

  To display the metadata must precede the title. Example:

  ```rst
  :author: Foo
  :date: 2021-04-20

  ========
  My Title
  ========
  ```
* The only supported properties _for now_ are `:author:`, `:date:`, and `:author_url:` if you want to link to your bio.