### PR TITLE
Improve Changelog

### DIFF
--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -104,3 +104,8 @@ img.avatar {
     font-size: x-small;
     text-align: right;
 }
+
+.topic .gitlog {
+    max-height: 300px;
+    overflow-y: auto;
+}

--- a/source/about/changelog.rst
+++ b/source/about/changelog.rst
@@ -3,5 +3,4 @@ Changelog
 =========
 
 .. git_changelog::
-    :detailed-message-pre: 1
     :filename_filter: source/.*\.rst

--- a/source/about/changelog.rst
+++ b/source/about/changelog.rst
@@ -4,3 +4,4 @@ Changelog
 
 .. git_changelog::
     :filename_filter: source/.*\.rst
+    :link-to-docs: 1

--- a/source/index.rst
+++ b/source/index.rst
@@ -31,6 +31,7 @@ Primarily using [UnrealEngine]_, but extensible enough to accommodate as many pr
       :class: shortlog
       :revisions: 3
       :filename_filter: source/.*\.rst
+      :link-to-docs: 1
 
    See :doc:`about/changelog` for all updates.
 


### PR DESCRIPTION
* The changelog now attempts to link to the files within the website instead of linking back to GItHub. If the files don't exist, it falls back to linking to GitHub.